### PR TITLE
feat: add image text section component

### DIFF
--- a/src/components/image_text_section/BulletList.js
+++ b/src/components/image_text_section/BulletList.js
@@ -1,0 +1,20 @@
+import {textType} from "../../constant";
+import DocText from "./DocText";
+
+const BulletList = ({content}) => {
+    return (
+        <ul className={"list-disc pl-[20px] marker:text-[#D1D5DB]"}>
+            {
+                content.map((detail) => {
+                    if (detail.type === textType.LIST_ITEM) {
+                        return (
+                            <li><DocText content={detail.content} /></li>
+                        )
+                    }
+                })
+            }
+        </ul>
+    )
+};
+
+export default BulletList;

--- a/src/components/image_text_section/Buttons.js
+++ b/src/components/image_text_section/Buttons.js
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+const Buttons = ({buttons}) => {
+    const themeClass = {
+        primary: "#6683D9"
+    }
+    const buttonSize = {
+        small: "px-4 py-2",
+        medium: "px-6 py-3",
+        large: "px-8 py-4"
+    }
+    // className={"bg-white text-[#6683D9] border-[#6683D9] text-sm font-thin py-2 px-4 rounded-full border"}
+    console.log(buttons);
+    return (<div>
+            {buttons.map((button) => {
+                const buttonColor = themeClass[button.button_color];
+                const btnSize = buttonSize[button.size];
+                return (
+                    <Link href={button.link.url}>
+                        <button
+                            className={`bg-${button.background_color} text-[${buttonColor}] border-[${buttonColor}] 
+                            text-sm font-thin py-2 px-4 rounded-full border ${btnSize}`}>
+                            {button.label}
+                        </button>
+                    </Link>
+                )
+            })}
+        </div>)
+};
+
+export default Buttons;

--- a/src/components/image_text_section/Buttons.js
+++ b/src/components/image_text_section/Buttons.js
@@ -9,8 +9,6 @@ const Buttons = ({buttons}) => {
         medium: "px-6 py-3",
         large: "px-8 py-4"
     }
-    // className={"bg-white text-[#6683D9] border-[#6683D9] text-sm font-thin py-2 px-4 rounded-full border"}
-    console.log(buttons);
     return (<div>
             {buttons.map((button) => {
                 const buttonColor = themeClass[button.button_color];

--- a/src/components/image_text_section/DocText.js
+++ b/src/components/image_text_section/DocText.js
@@ -1,0 +1,15 @@
+import TextComponentSelector from "./TextComponentSelector";
+
+const DocText = ({content}) => {
+    return (
+        <div>
+            {
+                content.map((contentDetail) => {
+                    return (<TextComponentSelector {...contentDetail} />);
+                })
+            }
+        </div>
+    )
+}
+
+export default DocText;

--- a/src/components/image_text_section/Headline.js
+++ b/src/components/image_text_section/Headline.js
@@ -1,0 +1,5 @@
+const Headline = ({headline}) => {
+  return <h1 className={"text-4xl font-medium pb-3"}>{headline}</h1>
+};
+
+export default Headline;

--- a/src/components/image_text_section/ImageTextSection.js
+++ b/src/components/image_text_section/ImageTextSection.js
@@ -1,0 +1,28 @@
+import Image from "next/image";
+import Headline from "./Headline";
+import TextComponentSelector from "./TextComponentSelector";
+import Buttons from "./Buttons";
+
+const ImageTextSection = ({blok}) => {
+    console.log(blok);
+    return (
+        <div className={"flex flex-row justify-center"}>
+            <div className={"w-[66%] flex flex-row justify-between"}>
+                <div className={"w-[40%]"}>
+                    <Image src={blok.image.filename} width={500} height={500} alt={blok.image.alt}/>
+                </div>
+                <div className={"text-left w-[55%] flex flex-col justify-center"}>
+                    <Headline headline={blok.headline}/>
+                    <div className={"text-[#59616E] text-base"}>
+                        <TextComponentSelector {...blok.text}/>
+                    </div>
+                    <div className="pt-4">
+                        <Buttons buttons={blok.button} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+};
+
+export default ImageTextSection;

--- a/src/components/image_text_section/Paragraph.js
+++ b/src/components/image_text_section/Paragraph.js
@@ -1,0 +1,21 @@
+import {textType} from "../../constant";
+
+const Paragraph = ({content}) => {
+    return (
+        <div>
+            {
+                content.map(({text, type}) => {
+                    if(type === textType.TEXT){
+                        return (
+                            <p className={"py-2"}>{text}</p>
+                        )
+                    } else {
+                        return (<p>Please edit another type here</p>)
+                    }
+                })
+            }
+        </div>
+    )
+};
+
+export default Paragraph;

--- a/src/components/image_text_section/TextComponentSelector.js
+++ b/src/components/image_text_section/TextComponentSelector.js
@@ -1,0 +1,23 @@
+import {textType} from "../../constant";
+import BulletList from "./BulletList";
+import Paragraph from "./Paragraph";
+import DocText from "./DocText";
+
+const TextComponentSelector = (({content, type}) => {
+    {
+        if (type === textType.BULL_LIST) {
+            return (<BulletList content={content} />)
+        }
+        if (type === textType.PARAGRAPH) {
+            return (<Paragraph content={content} />)
+        }
+        if (type === textType.DOC) {
+            return (<DocText content={content} />);
+        }
+        else {
+            return (<div>Please edit another type here</div>);
+        }
+    }
+});
+
+export default TextComponentSelector;

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,3 @@
+export const textType = {
+    DOC: "doc", PARAGRAPH: "paragraph", BULL_LIST: "bullet_list", TEXT: "text", LIST_ITEM: "list_item"
+}


### PR DESCRIPTION
## About MR
1. create image text section component for rendering the image and text from storyblok api call
2. main idea for this component is try to match the data in image-text-section and component, 
<img width="451" height="309" alt="image" src="https://github.com/user-attachments/assets/28d57c71-8420-4f70-ac44-1f80aa58e8c4" />

for example: you have data above with paragraph and bullet_list, try to make two component to match the data and handle different information
### ImageTextSection
mainly for display image and text, Entrance component when storyblok call "Image-Text-Section" component, below is child component
#### BulletList:
to display list, read bullet_list text type data
#### Headline
To display header, read headline from json data
#### DocText
To display document type text, read doc text type from json data under text attribute
#### Paragraph
To display paragraph, read paragraph text type from json data under text attribute
#### TextComponentSelector
Return different text component like DocText, Paragraph, BulletList base on the text type fetched from api,
because inside bullet list text type it also use paragraph to display list item.
#### Buttons
Display all buttons that specific in json data, under button attribute. Support auto apply different button size and theme from api data 

## Screenshot

https://github.com/user-attachments/assets/835ca4b7-5087-4eb2-bf32-ae640bc9d2a2

